### PR TITLE
Use NLPModels API for counters

### DIFF
--- a/src/State/NLPAtXmod.jl
+++ b/src/State/NLPAtXmod.jl
@@ -25,18 +25,17 @@ Tracked data include:
 
  - current_time  : time
  - current_score : score
- - evals [opt]   : number of evaluations of the function
  (import the type NLPModels.Counters)
 
 Constructors:
- `NLPAtX(:: T, :: T, :: S; fx :: eltype(T) = _init_field(eltype(T)), gx :: T = _init_field(T), Hx :: Matrix{eltype(T)} = _init_field(Matrix{eltype(T)}), mu :: T = _init_field(T), cx :: T = _init_field(T), Jx :: Matrix{eltype(T)} = _init_field(Matrix{eltype(T)}), d :: T = _init_field(T), res :: T = _init_field(T), current_time :: Float64 = NaN, evals :: Counters = Counters()) where {S, T <: AbstractVector}`
+ `NLPAtX(:: T, :: T, :: S; fx :: eltype(T) = _init_field(eltype(T)), gx :: T = _init_field(T), Hx :: Matrix{eltype(T)} = _init_field(Matrix{eltype(T)}), mu :: T = _init_field(T), cx :: T = _init_field(T), Jx :: Matrix{eltype(T)} = _init_field(Matrix{eltype(T)}), d :: T = _init_field(T), res :: T = _init_field(T), current_time :: Float64 = NaN) where {S, T <: AbstractVector}`
 
- `NLPAtX(:: T; fx :: eltype(T) = _init_field(eltype(T)), gx :: T = _init_field(T), Hx :: Matrix{eltype(T)} = _init_field(Matrix{eltype(T)}), mu :: T = _init_field(T), current_time :: Float64 = NaN, current_score :: Union{T,eltype(T)} = _init_field(eltype(T)), evals :: Counters  = Counters()) where {T <: AbstractVector}`
+ `NLPAtX(:: T; fx :: eltype(T) = _init_field(eltype(T)), gx :: T = _init_field(T), Hx :: Matrix{eltype(T)} = _init_field(Matrix{eltype(T)}), mu :: T = _init_field(T), current_time :: Float64 = NaN, current_score :: Union{T,eltype(T)} = _init_field(eltype(T))) where {T <: AbstractVector}`
 
- `NLPAtX(:: T, :: T; fx :: eltype(T) = _init_field(eltype(T)), gx :: T = _init_field(T), Hx :: Matrix{eltype(T)} = _init_field(Matrix{eltype(T)}), mu :: T = _init_field(T), cx :: T = _init_field(T), Jx :: Matrix{eltype(T)} = _init_field(Matrix{eltype(T)}), d :: T = _init_field(T), res :: T = _init_field(T), current_time :: Float64  = NaN, current_score :: Union{T,eltype(T)} = _init_field(eltype(T)), evals :: Counters = Counters()) where T <: AbstractVector`
+ `NLPAtX(:: T, :: T; fx :: eltype(T) = _init_field(eltype(T)), gx :: T = _init_field(T), Hx :: Matrix{eltype(T)} = _init_field(Matrix{eltype(T)}), mu :: T = _init_field(T), cx :: T = _init_field(T), Jx :: Matrix{eltype(T)} = _init_field(Matrix{eltype(T)}), d :: T = _init_field(T), res :: T = _init_field(T), current_time :: Float64  = NaN, current_score :: Union{T,eltype(T)} = _init_field(eltype(T))) where T <: AbstractVector`
 
 Note:
- - By default, unknown entries are set using `_init_field` (except evals).  
+ - By default, unknown entries are set using `_init_field`.  
  - By default the type of `current_score` is `eltype(x)` and cannot be changed once the State is created.  
     To have a vectorized `current_score` of length n, try something like `GenericState(x, Array{eltype(x),1}(undef, n))`.  
  - All these information (except for `x` and `lambda`) are optionnal and need to be update when
@@ -69,7 +68,6 @@ mutable struct 	NLPAtX{S, T <: AbstractVector,
   #Resources State
   current_time   :: Float64
   current_score  :: S
-  evals          :: Counters
 
   function NLPAtX(x            :: T,
                  lambda        :: T,
@@ -83,13 +81,12 @@ mutable struct 	NLPAtX{S, T <: AbstractVector,
                  d             :: T = _init_field(T),
                  res           :: T = _init_field(T),
                  current_time  :: Float64 = NaN,
-                 evals         :: Counters = Counters()
                  ) where {S, T <: AbstractVector}
 
     _size_check(x, lambda, fx, gx, Hx, mu, cx, Jx)
 
     return new{S, T, Matrix{eltype(T)}}(x, fx, gx, Hx, mu, cx, Jx, lambda, d, 
-                                        res, current_time, current_score, evals)
+                                        res, current_time, current_score)
   end
 end
 
@@ -105,14 +102,12 @@ function NLPAtX(x             :: T,
                 res           :: T = _init_field(T),
                 current_time  :: Float64  = NaN,
                 current_score :: Union{T,eltype(T)} = _init_field(eltype(T)),
-                evals         :: Counters     = Counters()
                 ) where T <: AbstractVector
 
   _size_check(x, lambda, fx, gx, Hx, mu, cx, Jx)
 
   return NLPAtX(x, lambda, current_score, fx = fx, gx = gx,
-               Hx = Hx, mu = mu, current_time = current_time,
-               evals = evals)
+               Hx = Hx, mu = mu, current_time = current_time)
 end
 
 function NLPAtX(x             :: T;
@@ -122,15 +117,13 @@ function NLPAtX(x             :: T;
                 mu            :: T = _init_field(T),
                 current_time  :: Float64 = NaN,
                 current_score :: Union{T,eltype(T)} = _init_field(eltype(T)),
-                evals         :: Counters     = Counters()
                 ) where {T <: AbstractVector}
 
   _size_check(x, zeros(eltype(T),0), fx, gx, Hx, mu, 
                 _init_field(T), _init_field(Matrix{eltype(T)}))
 
 	return NLPAtX(x, zeros(eltype(T),0), current_score, fx = fx, gx = gx,
-                  Hx = Hx, mu = mu, current_time = current_time,
-                  evals = evals)
+                  Hx = Hx, mu = mu, current_time = current_time)
 end
 
 """
@@ -140,7 +133,7 @@ reinit!: function that set all the entries at void except the mandatory x
 
 `reinit!(:: NLPAtX; kwargs...)`
 
-Note: if `x`, `lambda` or `evals` are given as keyword arguments they will be
+Note: if `x` or `lambda` are given as keyword arguments they will be
 prioritized over the existing `x`, `lambda` and the default `Counters`.
 """
 function reinit!(stateatx :: NLPAtX{S, T, MT}, 

--- a/src/Stopping/NLPStoppingmod.jl
+++ b/src/Stopping/NLPStoppingmod.jl
@@ -314,18 +314,14 @@ function _resources_check!(stp    :: NLPStopping,
   max_f = false
   if typeof(stp.pb.counters) == Counters
     for f in intersect(fieldnames(Counters), keys(max_cntrs))
-      max_f = max_f || (getfield(cntrs, f) > max_cntrs[f])
+      max_f = max_f || (eval(f)(stp.pb) > max_cntrs[f])
     end
   elseif typeof(stp.pb.counters) == NLSCounters
     for f in intersect(fieldnames(NLSCounters), keys(max_cntrs))
-      max_f = f != :counters ? (max_f || (getfield(cntrs, f) > max_cntrs[f])) : max_f
+      max_f = f != :counters ? (max_f || (eval(f)(stp.pb) > max_cntrs[f])) : max_f
     end
     for f in intersect(fieldnames(Counters), keys(max_cntrs))
-      max_f = max_f || (getfield(cntrs.counters, f) > max_cntrs[f])
-    end
-  else #Unknown counters type
-    for f in intersect(fieldnames(typeof(stp.pb.counters)), keys(max_cntrs))
-      max_f = max_f || (getfield(cntrs, f) > max_cntrs[f])
+      max_f = max_f || (eval(f)(stp.pb) > max_cntrs[f])
     end
   end
 

--- a/src/Stopping/NLPStoppingmod.jl
+++ b/src/Stopping/NLPStoppingmod.jl
@@ -300,10 +300,6 @@ Note:
 function _resources_check!(stp    :: NLPStopping,
                            x      :: T
                            ) where T <: Union{AbstractVector, Number}
-
-  cntrs = stp.pb.counters
-  update!(stp, evals = cntrs)
-
   max_cntrs = stp.meta.max_cntrs
 
   if max_cntrs == Dict{Symbol,Int64}()

--- a/src/Stopping/NLPStoppingmod.jl
+++ b/src/Stopping/NLPStoppingmod.jl
@@ -115,7 +115,7 @@ function NLPStopping(pb             :: Pb,
 end
 
 function NLPStopping(pb :: AbstractNLPModel;
-                     n_listofstates :: Int = 0,
+                     n_listofstates :: Integer = 0,
                      kwargs...)
   #Create a default NLPAtX
   nlp_at_x = NLPAtX(pb.meta.x0)
@@ -133,11 +133,11 @@ init\\_max\\_counters:
 initialize the maximum number of evaluations on each of
 the functions present in the NLPModels.Counters, e.g.
 
-`init_max_counters(; allevals :: T = 20000, obj = allevals, grad = allevals, cons = allevals, jcon = allevals, jgrad = allevals, jac = allevals, jprod = allevals, jtprod = allevals, hess = allevals, hprod = allevals, jhprod = allevals, sum = 11 * allevals, kwargs...)`
+`init_max_counters(; allevals :: T = typemax(T), obj = allevals, grad = allevals, cons = allevals, jcon = allevals, jgrad = allevals, jac = allevals, jprod = allevals, jtprod = allevals, hess = allevals, hprod = allevals, jhprod = allevals, sum = 11 * allevals, kwargs...)`
 
 `:neval_sum` is by default limited to `|Counters| * allevals`.
 """
-function init_max_counters(; allevals :: T = 20000, kwargs...) where {T <: Int}
+function init_max_counters(; allevals :: T = typemax(Int), kwargs...) where {T <: Integer}
 
   entries = [Meta.parse(split("$(f)", '_')[2]) for f in fieldnames(Counters)]
   lim_fields = keys(kwargs)
@@ -145,18 +145,18 @@ function init_max_counters(; allevals :: T = 20000, kwargs...) where {T <: Int}
     (Meta.parse("neval_$(t)"), t in lim_fields ? kwargs[t] : allevals) for t in entries
   ])
   push!(cntrs, 
-    (:neval_sum => :sum in lim_fields ? kwargs[:sum] : length(entries) * allevals )
+    (:neval_sum => :sum in lim_fields ? kwargs[:sum] : typemax(T) )
   )
 
   return cntrs
 end
 
-function max_evals!(stp :: NLPStopping, allevals :: Int)
+function max_evals!(stp :: NLPStopping, allevals :: Integer)
   stp.meta.max_cntrs = init_max_counters(allevals = allevals)
   return stp
 end
 
-function max_evals!(stp :: NLPStopping; allevals :: T = 20000, kwargs...) where {T <: Int}
+function max_evals!(stp :: NLPStopping; allevals :: T = typemax(Int), kwargs...) where {T <: Integer}
   stp.meta.max_cntrs = init_max_counters(allevals = allevals; kwargs...)
   return stp
 end
@@ -166,9 +166,9 @@ init\\_max\\_counters\\_NLS:
 initialize the maximum number of evaluations on each of
 the functions present in the `NLPModels.NLSCounters`, e.g.
 
-`init_max_counters_NLS(; allevals = 20000, residual = allevals, jac_residual = allevals, jprod_residual = allevals, jtprod_residual = allevals, hess_residual = allevals, jhess_residual = allevals, hprod_residual = allevals, kwargs...)`
+`init_max_counters_NLS(; allevals = typemax(T), residual = allevals, jac_residual = allevals, jprod_residual = allevals, jtprod_residual = allevals, hess_residual = allevals, jhess_residual = allevals, hprod_residual = allevals, kwargs...)`
 """
-function init_max_counters_NLS(; allevals :: T = 20000, kwargs...) where {T <: Int}
+function init_max_counters_NLS(; allevals :: T = typemax(Int), kwargs...) where {T <: Integer}
 
   cntrs_nlp = init_max_counters(; allevals = allevals, kwargs...)
 

--- a/test/examples/howtostate-nlp.jl
+++ b/test/examples/howtostate-nlp.jl
@@ -46,8 +46,6 @@ state_con = NLPAtX(x0, y0)
 #From the default initialization, all the other entries are void:
 @test state_unc.mu == [] && state_con.mu == []
 @test isnan(state_unc.fx) && isnan(state_con.fx)
-#exception is the counters which is initialized as a default Counters:
-@test (sum_counters(state_unc.evals) + sum_counters(state_con.evals)) == 0
 
 #Note that the constructor proceeds to a size checking on gx, Hx, mu, cx, Jx.
 #It returns an error if this test fails.
@@ -79,12 +77,7 @@ reinit!(state_bnd, mu = ones(6))
 #However, we can specify both entries
 reinit!(state_bnd, 2 * ones(6), zeros(0))
 @test state_bnd.x == 2*ones(6) && state_bnd.lambda == zeros(0)
-@test state_bnd.mu == [] && sum_counters(state_bnd.evals) == 0
-#Giving a new Counters update as well:
-test = Counters(); setfield!(test, :neval_obj, 102)
-reinit!(state_bnd, evals = test)
-@test getfield(state_bnd.evals, :neval_obj) == 102
-@test sum_counters(state_bnd.evals) - 102 == 0
+@test state_bnd.mu == []
 
 ###############################################################################
 #III. Domain Error

--- a/test/examples/howtostop-nlp.jl
+++ b/test/examples/howtostop-nlp.jl
@@ -68,8 +68,8 @@ fill_in!(stop_nlp_lazy, x1)
 #evaluations:
 @test typeof(stop_nlp.meta.max_cntrs) <: Dict
 #For instance the limit in evaluations of objective and gradient:
-@test stop_nlp.meta.max_cntrs[:neval_obj] == 20000
-@test stop_nlp.meta.max_cntrs[:neval_grad] == 20000
+@test stop_nlp.meta.max_cntrs[:neval_obj] == typemax(Int)
+@test stop_nlp.meta.max_cntrs[:neval_grad] == typemax(Int)
 
 #Limit can be set using init_max_counters function:
 stop_nlp.meta.max_cntrs = init_max_counters(obj = 3, grad = 0, hess = 0)

--- a/test/test-state/unit-test-NLPAtXmod.jl
+++ b/test/test-state/unit-test-NLPAtXmod.jl
@@ -13,7 +13,6 @@ uncons_nlp_at_x = NLPAtX(zeros(10))
 @test uncons_nlp_at_x.lambda == zeros(0)
 @test isnan(uncons_nlp_at_x.current_time)
 @test isnan(uncons_nlp_at_x.current_score)
-@test (!(uncons_nlp_at_x.evals == zeros(0,0)))
 
 #check constrained NLPAtX
 cons_nlp_at_x = NLPAtX(zeros(10), zeros(10))

--- a/test/test-stopping/test-unitaire-nlp-evals.jl
+++ b/test/test-stopping/test-unitaire-nlp-evals.jl
@@ -37,21 +37,4 @@
     @test nlp_stop_evals.meta.max_cntrs[:neval_sum]  == 10 * length(fieldnames(Counters))
     @test nlp_stop_evals.meta.max_cntrs[:neval_obj] == 2
 
-    #Test the case with a counters different from Counters and NLSCounters in NLPStopping
-    mutable struct Test_cntrs
-        neval     :: Int
-    end
-    mutable struct Test_pb <: AbstractNLPModel
-        counters :: Test_cntrs
-        meta     :: AbstractNLPModelMeta
-    end
-    NLPModels.sum_counters(pb :: Test_cntrs) = pb.neval
-    NLPModels.sum_counters(pb :: Test_pb) = sum_counters(pb.counters)
-    maxcount = Dict([(:neval, 1),(:neval_sum, -1)])
-
-    pb = Test_pb(Test_cntrs(0.0), NLPModelMeta(5, x0 = zeros(5)))
-    nls_stop_evals = NLPStopping(pb, max_cntrs = maxcount)
-    Stopping._resources_check!(nls_stop_evals, x0)
-    @test nls_stop_evals.meta.resources == true
-
 end

--- a/test/test-stopping/test-unitaire-nlp-evals.jl
+++ b/test/test-stopping/test-unitaire-nlp-evals.jl
@@ -30,11 +30,11 @@
 
     max_evals!(nlp_stop_evals, 10)
     @test nlp_stop_evals.meta.max_cntrs[:neval_obj] == 10
-    @test nlp_stop_evals.meta.max_cntrs[:neval_sum] == 10 * length(fieldnames(Counters))
+    @test nlp_stop_evals.meta.max_cntrs[:neval_sum] == typemax(Int)
 
     max_evals!(nlp_stop_evals, allevals = 10, obj = 2)
     @test nlp_stop_evals.meta.max_cntrs[:neval_cons] == 10
-    @test nlp_stop_evals.meta.max_cntrs[:neval_sum]  == 10 * length(fieldnames(Counters))
+    @test nlp_stop_evals.meta.max_cntrs[:neval_sum]  == typemax(Int)
     @test nlp_stop_evals.meta.max_cntrs[:neval_obj] == 2
 
 end

--- a/test/test-stopping/test-unitaire-nlp-stopping.jl
+++ b/test/test-stopping/test-unitaire-nlp-stopping.jl
@@ -38,8 +38,8 @@
   test_max_cntrs = init_max_counters(obj = 2)
   stop_nlp_cntrs = NLPStopping(nlp, max_cntrs = test_max_cntrs)
   @test stop_nlp_cntrs.meta.max_cntrs[:neval_obj] == 2
-  @test stop_nlp_cntrs.meta.max_cntrs[:neval_grad] == 20000
-  @test stop_nlp_cntrs.meta.max_cntrs[:neval_sum] == 20000 * length(fieldnames(Counters))
+  @test stop_nlp_cntrs.meta.max_cntrs[:neval_grad] == typemax(Int)
+  @test stop_nlp_cntrs.meta.max_cntrs[:neval_sum] == typemax(Int)
 
   reinit!(stop_nlp.current_state)
   @test unconstrained_check(stop_nlp.pb, stop_nlp.current_state) >= 0.0


### PR DESCRIPTION
instead of `nlp.counters`, which doesn't necessarily exist.

I also extended the default counters limit to maxtype(Int64).