### PR TITLE
Add warning when using unfilled `KKT`

### DIFF
--- a/src/Stopping/nlp_admissible_functions.jl
+++ b/src/Stopping/nlp_admissible_functions.jl
@@ -149,6 +149,17 @@ function KKT(
   kwargs...,
 ) where {S, T, HT, JT}
 
+  if unconstrained(pb) && state.gx == _init_field(typeof(state.gx))
+    @warn "KKT needs stp.current_state.gx to be filled-in."
+    return eltype(T)(Inf)
+  elseif has_bounds(pb) && state.mu == _init_field(typeof(state.mu))
+    @warn "KKT needs stp.current_state.mu to be filled-in."
+    return eltype(T)(Inf)
+  elseif get_ncon(pb) > 0 && (state.cx == _init_field(typeof(state.cx)) || state.Jx == _init_field(typeof(state.Jx)) || state.lambda == _init_field(typeof(state.lambda)))
+    @warn "KKT needs stp.current_state.cx, stp.current_state.Jx and stp.current_state.lambda to be filled-in."
+    return eltype(T)(Inf)
+  end
+
   #Check the gradient of the Lagrangian
   gLagx = _grad_lagrangian(pb, state)
   #Check the complementarity condition for the bounds

--- a/test/test-stopping/test-unitaire-nlp-stopping.jl
+++ b/test/test-stopping/test-unitaire-nlp-stopping.jl
@@ -6,6 +6,11 @@
 
   f(x) = x' * Q * x
   nlp = ADNLPModel(f, zeros(5))
+
+  stp_error = NLPStopping(nlp)
+  @test stop!(stp_error) # returns a warning "KKT needs stp.current_state.gx to be filled-in"
+  @test status(stp_error) == :Infeasible
+
   nlp_at_x = NLPAtX(zeros(5))
   meta = StoppingMeta(
     optimality0 = 0.0,
@@ -86,6 +91,11 @@
     f,
     x -> [],
   )
+
+  stp_error = NLPStopping(nlp_bnd)
+  @test stop!(stp_error) # returns a warning "KKT needs stp.current_state.mu to be filled-in"
+  @test status(stp_error) == :Infeasible
+
   stop_bnd = NLPStopping(nlp_bnd)
   fill_in!(stop_bnd, zeros(5))
   @test KKT(stop_bnd.pb, stop_bnd.current_state) == 0.0

--- a/test/test-stopping/test-unitaire-nlp-stopping_2.jl
+++ b/test/test-stopping/test-unitaire-nlp-stopping_2.jl
@@ -17,6 +17,10 @@
   nlp2 =
     ADNLPModel(meta, Counters(), ADNLPModels.ForwardDiffAD(6, 1, rosenbrock, x0), rosenbrock, c)
 
+  stp_error = NLPStopping(nlp2)
+  @test stop!(stp_error) # returns a warning "KKT needs stp.current_state.cx, stp.current_state.Jx and stp.current_state.lambda to be filled-in."
+  @test status(stp_error) == :Infeasible
+
   nlp_at_x_c = NLPAtX(x0, NaN * ones(nlp2.meta.ncon))
   stop_nlp_c = NLPStopping(nlp2, nlp_at_x_c)
 


### PR DESCRIPTION
+ this was causing a bug when calling `KKT` on a problem without filling in the state.